### PR TITLE
Bump '@fedify/fedify' to 1.0.2

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@fedify/fedify": "jsr:@fedify/fedify@^0.3.0",
+    "@fedify/fedify": "jsr:@fedify/fedify@^1.0.2",
     "badge-maker": "npm:badge-maker@^3.3.1",
     "hono": "https://deno.land/x/hono@v4.1.3/mod.ts"
   },

--- a/deno.lock
+++ b/deno.lock
@@ -2,94 +2,71 @@
   "version": "3",
   "packages": {
     "specifiers": {
-      "jsr:@fedify/fedify@^0.3.0": "jsr:@fedify/fedify@0.3.0",
-      "jsr:@std/assert@^0.219.1": "jsr:@std/assert@0.219.1",
-      "jsr:@std/async@^0.219.1": "jsr:@std/async@0.219.1",
-      "jsr:@std/bytes@^0.219.1": "jsr:@std/bytes@0.219.1",
-      "jsr:@std/cli@^0.219.1": "jsr:@std/cli@0.219.1",
-      "jsr:@std/encoding@^0.219.1": "jsr:@std/encoding@0.219.1",
-      "jsr:@std/fmt@^0.219.1": "jsr:@std/fmt@0.219.1",
-      "jsr:@std/http@^0.219.1": "jsr:@std/http@0.219.1",
-      "jsr:@std/json@^0.219.1": "jsr:@std/json@0.219.1",
-      "jsr:@std/media-types@^0.219.1": "jsr:@std/media-types@0.219.1",
-      "jsr:@std/path@^0.219.1": "jsr:@std/path@0.219.1",
-      "jsr:@std/semver@^0.219.1": "jsr:@std/semver@0.219.1",
-      "jsr:@std/streams@^0.219.1": "jsr:@std/streams@0.219.1",
-      "npm:@js-temporal/polyfill@^0.4.4": "npm:@js-temporal/polyfill@0.4.4",
-      "npm:@phensley/language-tag@^1.8.0": "npm:@phensley/language-tag@1.8.0",
+      "jsr:@fedify/fedify@^1.0.2": "jsr:@fedify/fedify@1.0.2",
+      "jsr:@hugoalh/http-header-link@^1.0.2": "jsr:@hugoalh/http-header-link@1.0.2",
+      "jsr:@hugoalh/is-string-singleline@1.0.2": "jsr:@hugoalh/is-string-singleline@1.0.2",
+      "jsr:@logtape/logtape@^0.6.2": "jsr:@logtape/logtape@0.6.2",
+      "jsr:@std/bytes@^1.0.2": "jsr:@std/bytes@1.0.2",
+      "jsr:@std/encoding@^1.0.5": "jsr:@std/encoding@1.0.5",
+      "jsr:@std/http@^1.0.6": "jsr:@std/http@1.0.7",
+      "jsr:@std/semver@^1.0.3": "jsr:@std/semver@1.0.3",
+      "npm:@phensley/language-tag@^1.9.0": "npm:@phensley/language-tag@1.9.0",
+      "npm:asn1js@^3.0.5": "npm:asn1js@3.0.5",
       "npm:badge-maker@^3.3.1": "npm:badge-maker@3.3.1",
       "npm:create-hono": "npm:create-hono@0.5.0",
-      "npm:jose@^5.2.3": "npm:jose@5.2.3",
+      "npm:json-canon@^1.0.1": "npm:json-canon@1.0.1",
       "npm:jsonld@^8.3.2": "npm:jsonld@8.3.2",
+      "npm:multibase@^4.0.6": "npm:multibase@4.0.6",
+      "npm:multicodec@^3.2.1": "npm:multicodec@3.2.1",
+      "npm:pkijs@^3.2.4": "npm:pkijs@3.2.4",
       "npm:superjson@1.13.3": "npm:superjson@1.13.3",
       "npm:uri-template-router@^0.0.16": "npm:uri-template-router@0.0.16",
       "npm:url-template@^3.1.1": "npm:url-template@3.1.1"
     },
     "jsr": {
-      "@fedify/fedify@0.3.0": {
-        "integrity": "b89fd849d182d7bea22cb86862155c7fa342d726e160588bc9f2c2b9e8c0edee",
+      "@fedify/fedify@1.0.2": {
+        "integrity": "e2ad764a08112776110518504d20f82c28c4e7455439e62c48d093dbd4911510",
         "dependencies": [
-          "jsr:@std/bytes@^0.219.1",
-          "jsr:@std/encoding@^0.219.1",
-          "jsr:@std/http@^0.219.1",
-          "jsr:@std/json@^0.219.1",
-          "jsr:@std/semver@^0.219.1",
-          "npm:@js-temporal/polyfill@^0.4.4",
-          "npm:@phensley/language-tag@^1.8.0",
-          "npm:jose@^5.2.3",
+          "jsr:@hugoalh/http-header-link@^1.0.2",
+          "jsr:@logtape/logtape@^0.6.2",
+          "jsr:@std/bytes@^1.0.2",
+          "jsr:@std/encoding@^1.0.5",
+          "jsr:@std/http@^1.0.6",
+          "jsr:@std/semver@^1.0.3",
+          "npm:@phensley/language-tag@^1.9.0",
+          "npm:asn1js@^3.0.5",
+          "npm:json-canon@^1.0.1",
           "npm:jsonld@^8.3.2",
+          "npm:multibase@^4.0.6",
+          "npm:multicodec@^3.2.1",
+          "npm:pkijs@^3.2.4",
           "npm:uri-template-router@^0.0.16",
           "npm:url-template@^3.1.1"
         ]
       },
-      "@std/assert@0.219.1": {
-        "integrity": "e76c2a1799a78f0f4db7de04bdc9b908a7a4b821bb65eda0285885297d4fb8af"
-      },
-      "@std/async@0.219.1": {
-        "integrity": "9401a6aa5a3292d639b71beceb19fb53c2148238c4d36b3ddf8c30980baa10e0"
-      },
-      "@std/bytes@0.219.1": {
-        "integrity": "693e5f3f7796b33a448fb16c448b75d7d6e62914b55e2f1f715f9a04f77853b4"
-      },
-      "@std/cli@0.219.1": {
-        "integrity": "715a9926b58b89ef8a3c91e91633ac5f8176e0f02f6b3a16f0a67309e41a2911"
-      },
-      "@std/encoding@0.219.1": {
-        "integrity": "77b30e481a596cfb2a8f2f38c3165e6035a4f76a7259bf89b6a622ceaf57d575"
-      },
-      "@std/fmt@0.219.1": {
-        "integrity": "2432152e927df249a207177aa048a6d9465956ea0047653ee6abd4f514db504f"
-      },
-      "@std/http@0.219.1": {
-        "integrity": "444b9e212747a4a163f5d9f5e468d1159e3ff9915cbc60a5bac6043f4771649a",
+      "@hugoalh/http-header-link@1.0.2": {
+        "integrity": "1f607e34ac0790a0b0759f89ade294ab3a1d211e46a8dea337eaafa26950205f",
         "dependencies": [
-          "jsr:@std/assert@^0.219.1",
-          "jsr:@std/async@^0.219.1",
-          "jsr:@std/cli@^0.219.1",
-          "jsr:@std/encoding@^0.219.1",
-          "jsr:@std/fmt@^0.219.1",
-          "jsr:@std/media-types@^0.219.1",
-          "jsr:@std/path@^0.219.1",
-          "jsr:@std/streams@^0.219.1"
+          "jsr:@hugoalh/is-string-singleline@1.0.2"
         ]
       },
-      "@std/json@0.219.1": {
-        "integrity": "f997d8cfdff0e55fd2cdc797c6357e916494106830539b0e8ddb34408c0e49db",
-        "dependencies": [
-          "jsr:@std/streams@^0.219.1"
-        ]
+      "@hugoalh/is-string-singleline@1.0.2": {
+        "integrity": "f79dc9930bd89f3534db2efc93293fde5af81648dacbb87afd921cd6a163c9bd"
       },
-      "@std/media-types@0.219.1": {
-        "integrity": "557c8d4fd82aa6df51bca18d14e08e8df7134816c8defb61c90ac48bf71ad7c4"
+      "@logtape/logtape@0.6.2": {
+        "integrity": "80a5a203bb6775c46ede31d0582502f238811cc44e54a1e53631480c48e2df04"
       },
-      "@std/path@0.219.1": {
-        "integrity": "e5c0ffef3a8ef2b48e9e3d88a1489320e8fb2cc7be767b17c91a1424ffb4c8ed"
+      "@std/bytes@1.0.2": {
+        "integrity": "fbdee322bbd8c599a6af186a1603b3355e59a5fb1baa139f8f4c3c9a1b3e3d57"
       },
-      "@std/semver@0.219.1": {
-        "integrity": "1640e3368144090857ded3e944aa8743806bea712d5122c9fee2e9eb23c81607"
+      "@std/encoding@1.0.5": {
+        "integrity": "ecf363d4fc25bd85bd915ff6733a7e79b67e0e7806334af15f4645c569fefc04"
       },
-      "@std/streams@0.219.1": {
-        "integrity": "6f5dac5773a4fafdbe7ee612d0a0d5a2cbe465b9c9e2c85d371877dc8a52d1d3"
+      "@std/http@1.0.7": {
+        "integrity": "9b904fc256678a5c9759f1a53a24a3fdcc59d83dc62099bb472683b6f819194c"
+      },
+      "@std/semver@1.0.3": {
+        "integrity": "7c139c6076a080eeaa4252c78b95ca5302818d7eafab0470d34cafd9930c13c8"
       }
     },
     "npm": {
@@ -98,24 +75,25 @@
         "dependencies": {
           "ky": "ky@0.33.3",
           "ky-universal": "ky-universal@0.11.0_ky@0.33.3",
-          "undici": "undici@5.28.3"
+          "undici": "undici@5.28.4"
         }
       },
       "@fastify/busboy@2.1.1": {
         "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
         "dependencies": {}
       },
-      "@js-temporal/polyfill@0.4.4": {
-        "integrity": "sha512-2X6bvghJ/JAoZO52lbgyAPFj8uCflhTo2g7nkFzEQdXd/D8rEeD4HtmTEpmtGCva260fcd66YNXBOYdnmHqSOg==",
-        "dependencies": {
-          "jsbi": "jsbi@4.3.0",
-          "tslib": "tslib@2.6.2"
-        }
+      "@multiformats/base-x@4.0.1": {
+        "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==",
+        "dependencies": {}
       },
-      "@phensley/language-tag@1.8.0": {
-        "integrity": "sha512-9zUKCZ2T4dtdaQs/hlcuDh5etH60ncUDBi5UlRuzzloXxmgLO/TNC3u6uYAzz4GBfDh787rVfOr/JnjNKAalyw==",
+      "@noble/hashes@1.5.0": {
+        "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+        "dependencies": {}
+      },
+      "@phensley/language-tag@1.9.0": {
+        "integrity": "sha512-nj2uFsnp2SSD/DEGvLqcrpTXerIe9yShGndnwY7p3Z6Ep4m6+GkrgZCNJUc8rKcXWgQmRGC2TUzwG/LlBVtuCA==",
         "dependencies": {
-          "tslib": "tslib@2.6.2"
+          "tslib": "tslib@2.7.0"
         }
       },
       "abort-controller@3.0.0": {
@@ -130,6 +108,14 @@
           "char-width-table-consumer": "char-width-table-consumer@1.0.0"
         }
       },
+      "asn1js@3.0.5": {
+        "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+        "dependencies": {
+          "pvtsutils": "pvtsutils@1.3.5",
+          "pvutils": "pvutils@1.1.3",
+          "tslib": "tslib@2.7.0"
+        }
+      },
       "badge-maker@3.3.1": {
         "integrity": "sha512-OO/PS7Zg2E6qaUWzHEHt21Q5VjcFBAJVA8ztgT/fIdSZFBUwoyeo0ZhA6V5tUM8Vcjq8DJl6jfGhpjESssyqMQ==",
         "dependencies": {
@@ -139,6 +125,10 @@
       },
       "binary-search@1.3.6": {
         "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==",
+        "dependencies": {}
+      },
+      "bytestreamjs@2.0.1": {
+        "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
         "dependencies": {}
       },
       "canonicalize@1.0.8": {
@@ -206,12 +196,8 @@
         "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
         "dependencies": {}
       },
-      "jose@5.2.3": {
-        "integrity": "sha512-KUXdbctm1uHVL8BYhnyHkgp3zDX5KW8ZhAKVFEfUbU2P8Alpzjb+48hHvjOdQIyPshoblhzsuqOwEEAbtHVirA==",
-        "dependencies": {}
-      },
-      "jsbi@4.3.0": {
-        "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g==",
+      "json-canon@1.0.1": {
+        "integrity": "sha512-PQcj4PFOTAQxE8PgoQ4KrM0DcKWZd7S3ELOON8rmysl9I8JuFMgxu1H9v+oZsTPjjkpeS3IHPwLjr7d+gKygnw==",
         "dependencies": {}
       },
       "jsonld@8.3.2": {
@@ -241,6 +227,23 @@
           "yallist": "yallist@4.0.0"
         }
       },
+      "multibase@4.0.6": {
+        "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
+        "dependencies": {
+          "@multiformats/base-x": "@multiformats/base-x@4.0.1"
+        }
+      },
+      "multicodec@3.2.1": {
+        "integrity": "sha512-+expTPftro8VAW8kfvcuNNNBgb9gPeNYV9dn+z1kJRWF2vih+/S79f2RVeIwmrJBUJ6NT9IUPWnZDQvegEh5pw==",
+        "dependencies": {
+          "uint8arrays": "uint8arrays@3.1.1",
+          "varint": "varint@6.0.0"
+        }
+      },
+      "multiformats@9.9.0": {
+        "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+        "dependencies": {}
+      },
       "node-domexception@1.0.0": {
         "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
         "dependencies": {}
@@ -252,6 +255,27 @@
           "fetch-blob": "fetch-blob@3.2.0",
           "formdata-polyfill": "formdata-polyfill@4.0.10"
         }
+      },
+      "pkijs@3.2.4": {
+        "integrity": "sha512-Et9V5QpvBilPFgagJcaKBqXjKrrgF5JL2mSDELk1vvbOTt4fuBhSSsGn9Tcz0TQTfS5GCpXQ31Whrpqeqp0VRg==",
+        "dependencies": {
+          "@noble/hashes": "@noble/hashes@1.5.0",
+          "asn1js": "asn1js@3.0.5",
+          "bytestreamjs": "bytestreamjs@2.0.1",
+          "pvtsutils": "pvtsutils@1.3.5",
+          "pvutils": "pvutils@1.1.3",
+          "tslib": "tslib@2.7.0"
+        }
+      },
+      "pvtsutils@1.3.5": {
+        "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
+        "dependencies": {
+          "tslib": "tslib@2.7.0"
+        }
+      },
+      "pvutils@1.1.3": {
+        "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+        "dependencies": {}
       },
       "rdf-canonize@3.4.0": {
         "integrity": "sha512-fUeWjrkOO0t1rg7B2fdyDTvngj+9RlUyL92vOdiB7c0FPguWVsniIMjEtHH+meLBO9rzkUlUzBVXgWrjI8P9LA==",
@@ -269,12 +293,18 @@
           "copy-anything": "copy-anything@3.0.5"
         }
       },
-      "tslib@2.6.2": {
-        "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "tslib@2.7.0": {
+        "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
         "dependencies": {}
       },
-      "undici@5.28.3": {
-        "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
+      "uint8arrays@3.1.1": {
+        "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+        "dependencies": {
+          "multiformats": "multiformats@9.9.0"
+        }
+      },
+      "undici@5.28.4": {
+        "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
         "dependencies": {
           "@fastify/busboy": "@fastify/busboy@2.1.1"
         }
@@ -285,6 +315,10 @@
       },
       "url-template@3.1.1": {
         "integrity": "sha512-4oszoaEKE/mQOtAmdMWqIRHmkxWkUZMnXFnjQ5i01CuRSK3uluxcH1MRVVVWmhlnzT1SCDfKxxficm2G37qzCA==",
+        "dependencies": {}
+      },
+      "varint@6.0.0": {
+        "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
         "dependencies": {}
       },
       "web-streams-polyfill@3.3.3": {
@@ -302,10 +336,12 @@
     "https://deno.land/std@0.203.0/dotenv/mod.ts": "1da8c6d0e7f7d8a5c2b19400b763bc11739df24acec235dda7ea2cfd3d300057",
     "https://deno.land/x/hono@v4.1.3/client/client.ts": "b9d07d47a7b23f007fb2ea29a3185885e85a963a63b0f921f93ae2981ee29cda",
     "https://deno.land/x/hono@v4.1.3/client/index.ts": "30def535310a37bede261f1b23d11a9758983b8e9d60a6c56309cee5f6746ab2",
+    "https://deno.land/x/hono@v4.1.3/client/types.ts": "0c131d0bcc205c18e6c2e858be1bf3886907594c69563f4ab3264bbe81f5ecd0",
     "https://deno.land/x/hono@v4.1.3/client/utils.ts": "a93e5dc542dceb892a6b39cc793689478627ba958d251794193cf26c0ecf5800",
     "https://deno.land/x/hono@v4.1.3/compose.ts": "37d6e33b7db80e4c43a0629b12fd3a1e3406e7d9e62a4bfad4b30426ea7ae4f1",
     "https://deno.land/x/hono@v4.1.3/context.ts": "3d8c8a1aaea396fe22e2db822e1a270482c7f4b3b273f8f05ae3b240408bc7b2",
     "https://deno.land/x/hono@v4.1.3/helper/cookie/index.ts": "80b98f8a014e8b03a9130cce9fb03f6175f82a64367e954d120634f8543556e2",
+    "https://deno.land/x/hono@v4.1.3/helper/websocket/index.ts": "d72e052f0b6bfd98c26c4348ad499b493b2baf24bfdaae81b399453dcdad1483",
     "https://deno.land/x/hono@v4.1.3/hono-base.ts": "d3323a4668796cd56b9061ad34f2fa12a3c52178890cfffe27bd077e263c0ab7",
     "https://deno.land/x/hono@v4.1.3/hono.ts": "23edd0140bf0bd5a68c14ae96e5856a5cec6b844277e853b91025e91ea74f416",
     "https://deno.land/x/hono@v4.1.3/http-exception.ts": "cd387c6f7357db375ac3375f0346c6da80b46193b661881f660d6b15293fc086",
@@ -325,18 +361,21 @@
     "https://deno.land/x/hono@v4.1.3/router/trie-router/index.ts": "3eb75e7f71ba81801631b30de6b1f5cefb2c7239c03797e2b2cbab5085911b41",
     "https://deno.land/x/hono@v4.1.3/router/trie-router/node.ts": "5786ed7b85bb55411ede249a381412d39406497285ce23c1eafd50551dcdc632",
     "https://deno.land/x/hono@v4.1.3/router/trie-router/router.ts": "54ced78d35676302c8fcdda4204f7bdf5a7cc907fbf9967c75674b1e394f830d",
+    "https://deno.land/x/hono@v4.1.3/types.ts": "c08fe4c475f8ee84b89a2325c128bb34a44d26a8a834e8e9ee32d3381c81d43c",
     "https://deno.land/x/hono@v4.1.3/utils/body.ts": "1c7013f83bbef8216b3d862111efd5a183eaa29e86decf9a7eec6cdf25757e93",
     "https://deno.land/x/hono@v4.1.3/utils/buffer.ts": "9066a973e64498cb262c7e932f47eed525a51677b17f90893862b7279dc0773e",
     "https://deno.land/x/hono@v4.1.3/utils/cookie.ts": "6eaaf6909a4ae11f6c82404e9398e1c247e3f1854d73994a9e2e6fc3cdf7b584",
     "https://deno.land/x/hono@v4.1.3/utils/crypto.ts": "bda0e141bbe46d3a4a20f8fbcb6380d473b617123d9fdfa93e4499410b537acc",
     "https://deno.land/x/hono@v4.1.3/utils/html.ts": "6ea4f6bf41587a51607dff7a6d2865ef4d5001e4203b07e5c8a45b63a098e871",
+    "https://deno.land/x/hono@v4.1.3/utils/http-status.ts": "f5b820f2793e45209f34deddf147b23e3133a89eb4c57dc643759a504706636b",
+    "https://deno.land/x/hono@v4.1.3/utils/types.ts": "47426b7de99a75aa39305a21868c8d8e8d1316d24136a2d35fdf24e15f72970c",
     "https://deno.land/x/hono@v4.1.3/utils/url.ts": "855169632c61d03703bd08cafb27664ba3fdb352892f01687d5cce8fd49e3cb1",
     "https://deno.land/x/hono@v4.1.3/validator/index.ts": "6c986e8b91dcf857ecc8164a506ae8eea8665792a4ff7215471df669c632ae7c",
     "https://deno.land/x/hono@v4.1.3/validator/validator.ts": "480a8fd7f9c750fca3c8bd196d858bc928ad96f73318de5f13e7712176afd658"
   },
   "workspace": {
     "dependencies": [
-      "jsr:@fedify/fedify@^0.3.0",
+      "jsr:@fedify/fedify@^1.0.2",
       "npm:badge-maker@^3.3.1"
     ]
   }


### PR DESCRIPTION
## Context

A few days ago, Fedify released 1.0.0! [^1] 🎉🎉🎉

So this pull request bumped the `@fedify/fedify` dependency in this project.

[^1]: https://github.com/dahlia/fedify/discussions/141

## Test

> [!NOTE]
> I didn't know Deno Deploy Preview feature is setup. It will be better to use the Preview link.

I deployed this branch with Deno Deploy (may be used by this project) and you can test it in https://moreal-fedi-badge-65-01kxpew20kjd.deno.dev/

The following items are links for easy testing (without typing while reviewing)

- https://moreal-fedi-badge-65-01kxpew20kjd.deno.dev/@hongminhee@fosstodon.org/followers.svg
- https://moreal-fedi-badge-65-01kxpew20kjd.deno.dev/@hongminhee@fosstodon.org/followers.svg?style=flat
- https://moreal-fedi-badge-65-01kxpew20kjd.deno.dev/@hongminhee@fosstodon.org/following.svg
- https://moreal-fedi-badge-65-01kxpew20kjd.deno.dev/@hongminhee@fosstodon.org/following.svg?style=flat
- https://moreal-fedi-badge-65-01kxpew20kjd.deno.dev/@hongminhee@fosstodon.org/posts.svg
- https://moreal-fedi-badge-65-01kxpew20kjd.deno.dev/@hongminhee@fosstodon.org/posts.svg?style=flat

With deno-deploy Preview links:

- https://fedi-badge-0zaxwakgqzhj.deno.dev/@hongminhee@fosstodon.org/followers.svg
- https://fedi-badge-0zaxwakgqzhj.deno.dev/@hongminhee@fosstodon.org/followers.svg?style=flat
- https://fedi-badge-0zaxwakgqzhj.deno.dev/@hongminhee@fosstodon.org/following.svg
- https://fedi-badge-0zaxwakgqzhj.deno.dev/@hongminhee@fosstodon.org/following.svg?style=flat
- https://fedi-badge-0zaxwakgqzhj.deno.dev/@hongminhee@fosstodon.org/posts.svg
- https://fedi-badge-0zaxwakgqzhj.deno.dev/@hongminhee@fosstodon.org/posts.svg?style=flat